### PR TITLE
Add pr_number to github_info

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Checkout benchmarks
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Setup R
         uses: r-lib/actions/setup-r@v1
       - name: Lint (black)

--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -21,8 +21,12 @@ def _now_formatted() -> str:
 
 
 def github_info(arrow_info: Dict[str, Any]) -> Dict[str, Any]:
+    pr_number_env = os.getenv("BENCHMARKABLE_PR_NUMBER", "")
+    pr_number = int(pr_number_env) if pr_number_env else None
+
     return {
         "repository": "https://github.com/apache/arrow",
+        "pr_number": pr_number,
         "commit": arrow_info["arrow_git_revision"],
     }
 


### PR DESCRIPTION
This PR passes the Arrow PR number to Conbench in the github info dict. This will enable better Conbench history tracking.