### PR TITLE
Don't provide pr_number if it's not a PR

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -23,7 +23,8 @@ def _now_formatted() -> str:
 
 def github_info(arrow_info: Dict[str, Any]) -> Dict[str, Any]:
     pr_number_env = os.getenv("BENCHMARKABLE_PR_NUMBER", "")
-    pr_number = int(pr_number_env) if pr_number_env else None
+    is_pr = os.getenv("RUN_REASON", "") == "pull request"
+    pr_number = int(pr_number_env) if pr_number_env and is_pr else None
 
     return {
         "repository": "https://github.com/apache/arrow",


### PR DESCRIPTION
We shouldn't be providing `pr_number` to Conbench if the benchmark isn't running on a PR.