### PR TITLE
benchmarks.json: tweak dataset-serialize invocation

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -68,7 +68,7 @@
     }
   },
   {
-    "command": "dataset-serialize ALL --iterations=3 --all=true --drop-caches=true",
+    "command": "dataset-serialize ALL --iterations=6 --all=true",
     "flags": {
       "language": "Python"
     }


### PR DESCRIPTION
I hope that this passes CI (i.e., I hope that the automatic check does not require `--iterations=3 --drop-caches=true`.