### PR TITLE
Use hostname from .conbench config in cpp adapter

### DIFF
--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -95,15 +95,20 @@ class RecordCppMicroBenchmarks(_benchmark.Benchmark):
     adapter = None
 
     def __init__(self):
+        # first so `.conbench` attribute exists
+        super().__init__()
         # populates arrow metadata like compiler flags from pyarrow
         tags, info, context = self._get_tags_info_context(case=None, extra_tags={})
 
         self.adapter = ArcheryAdapter(
             # populates commit and repo based on arrow info rather than current status
-            result_fields_override={"github": self.github_info},
+            result_fields_override={
+                "github": self.github_info,
+                # this version grabs hostname from the `.conbench` file
+                "machine_info": self.conbench.machine_info,
+            },
             result_fields_append={"tags": tags, "info": info, "context": context},
         )
-        super().__init__()
 
     def run(self, **kwargs):
         run_reason = kwargs.get("run_reason")


### PR DESCRIPTION
Per Elena, the cpp microbenchmarks were sending the wrong hostname, e.g. [this one](https://conbench.ursa.dev/benchmarks/40c3117c1ee141c2b167af3202a6fc8a/) should be a generic AWS name instead of the actual AWS machine name.

This uses `self.conbench.machine_info` attribute for the cpp adapter because that grabs the hostname from the `.conbench` config file, if populated, which is how we're populating `machine_info.name` on some runners.

Long-term, we need to think about how and where we want to store this type of metadata, given we've moved a lot of other things from `.conbench` to env vars. Given I'll need to reconfigure this whole thing anyway to run the adapter directly from arrow-benchmarks-ci, I'm ok with this short-term patch (which is really what most of this file is), as I'll have a better view then of all the other data like this we'll need to wrangle and hopefully have a more useful opinion about how to handle it.