### PR TITLE
Remove use_async argument in dataset.to_table call

### DIFF
--- a/benchmarks/dataset_read_benchmark.py
+++ b/benchmarks/dataset_read_benchmark.py
@@ -46,7 +46,7 @@ class DatasetReadBenchmark(_benchmark.Benchmark):
                     break  # no need to run the null legacy case twice
 
     def _get_benchmark_function(self, dataset):
-        return lambda: dataset.to_table(use_async=True)
+        return lambda: dataset.to_table()
 
     def _get_schema(self, source):
         # TODO: FileSystemDataset.from_paths() can't currently discover

--- a/benchmarks/dataset_serialize_benchmark.py
+++ b/benchmarks/dataset_serialize_benchmark.py
@@ -182,7 +182,6 @@ class DatasetSerializeBenchmark(_benchmark.Benchmark):
         cases = self.get_cases(case, kwargs)
 
         for source in self.get_sources(source):
-
             log.info("source %s: download, if required", source.name)
             source.download_source_if_not_exists()
             tags = self.get_tags(kwargs, source)
@@ -194,7 +193,6 @@ class DatasetSerializeBenchmark(_benchmark.Benchmark):
             )
 
             for case in cases:
-
                 log.info("case %s: create directory", case)
                 dirpath = self._create_tmpdir_in_ramdisk(case)
                 log.info("directory created, path: %s", dirpath)
@@ -224,7 +222,6 @@ class DatasetSerializeBenchmark(_benchmark.Benchmark):
     def _get_benchmark_function(
         self, case, source_name: str, source_ds: ds.Dataset, dirpath: str
     ):
-
         (selectivity, serialization_format) = case
 
         # Option A: read-from-disk -> deserialize -> filter -> into memory


### PR DESCRIPTION
The use_async parameter has been removed in https://github.com/apache/arrow/pull/34034