### PR TITLE
Use benchclients.ConbenchClient to post benchmarks

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -54,8 +54,11 @@ def arrow_info() -> Dict[str, Any]:
 
 
 class ConbenchCommunicator(conbench.runner.Conbench):
+    """Exactly the same as the legacy "Conbench" communication object, with the
+    publish() method overridden to use the new retrying client.
+    """
+
     def publish(self, benchmark: dict) -> None:
-        """Publish benchmark results to Conbench using the new retrying client."""
         # Put login information into environment variables so the new client can access it
         os.environ["CONBENCH_URL"] = self.config.login_url.split("/api/login")[0]
         os.environ["CONBENCH_EMAIL"] = self.config.credentials["email"]
@@ -70,6 +73,8 @@ class Benchmark(conbench.runner.Benchmark):
 
     def __init__(self):
         super().__init__()
+        # Override the "conbench" object that was set during super().__init__()
+        # so that we can use the new retrying client.
         self.conbench = ConbenchCommunicator()
 
     @functools.cached_property

--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -54,18 +54,14 @@ def arrow_info() -> Dict[str, Any]:
 
 
 class ConbenchCommunicator(conbench.runner.Conbench):
-    def __init__(self):
-        super().__init__()
-
+    def publish(self, benchmark: dict) -> None:
+        """Publish benchmark results to Conbench using the new retrying client."""
         # Put login information into environment variables so the new client can access it
         os.environ["CONBENCH_URL"] = self.config.login_url.split("/api/login")[0]
         os.environ["CONBENCH_EMAIL"] = self.config.credentials["email"]
         os.environ["CONBENCH_PASSWORD"] = self.config.credentials["password"]
 
-        self._conbench_client = ConbenchClient()
-
-    def publish(self, benchmark: dict) -> None:
-        self._conbench_client.post("/api/benchmarks", benchmark)
+        ConbenchClient().post("/api/benchmarks", benchmark)
 
 
 class Benchmark(conbench.runner.Benchmark):


### PR DESCRIPTION
This PR addresses https://github.com/voltrondata-labs/arrow-benchmarks-ci/issues/121 by overwriting the `publish()` method that most benchmarks use to post benchmark results to Conbench. It now should use the new `benchclients.ConbenchClient`, which has more reasonable retrying logic.