### PR TITLE
Ensure default for optional_benchmark_info is {}

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -160,7 +160,7 @@ class Benchmark(conbench.runner.Benchmark):
             tags=tags,
             info=info,
             context=context,
-            optional_benchmark_info=optional_benchmark_info,
+            optional_benchmark_info=optional_benchmark_info or {},
             github=self.github_info,
             options=options,
             output=output,
@@ -342,7 +342,7 @@ class BenchmarkR(Benchmark):
             error=error,
             case=case,
             output=output,
-            optional_benchmark_info=result.get("optional_benchmark_info", None),
+            optional_benchmark_info=result.get("optional_benchmark_info") or {},
         )
 
     def r_cpu_count(self, options: Dict[str, Any]):


### PR DESCRIPTION
#143 caused some builds to start failing because in some cases (archery runs for Java and JavaScript) `optional_benchmark_info` was `None` instead of `{}`, which then causes the result to get rejected by the Conbench API. This changes the defaults for `optional_benchmark_info` so they will always be `{}` if otherwise unpopulated.

Example failed builds:

- JavaScript: https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-ursa-i9-9960x/builds/3103#0188e55e-11a5-4f01-a51b-b505158876e7/6-438
- Java: https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-ursa-thinkcentre-m75q/builds/3130#0188e55e-157d-46b3-9ab1-8202971e6629/6-5019