### PR TITLE
Post catastrophic errors to Conbench

### DIFF
--- a/benchmarks/_benchmark.py
+++ b/benchmarks/_benchmark.py
@@ -278,7 +278,12 @@ class Benchmark(conbench.runner.Benchmark):
         }
         if r_command is not None:
             result["error"]["command"] = r_command
-        logging.exception(f"Errored result (not posted): {json.dumps(result)}")
+
+        logging.exception(f"Errored result: {json.dumps(result)}")
+
+        if os.environ.get("DRY_RUN") is None:
+            self.conbench.publish(result)
+
         return result, output
 
 


### PR DESCRIPTION
Closes #145 by posting catastrophic errors instead of just logging them. No tests because we don't have mocks set up for this repo 😢 . 

Uses the `publish()` method directly instead of `record()`, which is different than everything else here, but which is good for moving away from the legacy runner.