### PR TITLE
Fix dataset-serialize benchmark by setting pre_buffer=False

### DIFF
--- a/benchmarks/dataset_serialize_benchmark.py
+++ b/benchmarks/dataset_serialize_benchmark.py
@@ -244,11 +244,13 @@ class DatasetSerializeBenchmark(_benchmark.Benchmark):
             log.info("read %s rows of dataset %s into memory", n_rows_only, source_name)
             data = source_ds.head(
                 n_rows_only,
+                # Need this or arrow#38438 will cause a segfault.
                 fragment_scan_options=ds.ParquetFragmentScanOptions(pre_buffer=False),
             )
         else:
             log.info("read complete dataset %s into memory", source_name)
             data = source_ds.to_table(
+                # Need this or arrow#38438 will cause a segfault.
                 fragment_scan_options=ds.ParquetFragmentScanOptions(pre_buffer=False)
             )
 

--- a/benchmarks/dataset_serialize_benchmark.py
+++ b/benchmarks/dataset_serialize_benchmark.py
@@ -242,10 +242,15 @@ class DatasetSerializeBenchmark(_benchmark.Benchmark):
             # Note that `head()` returns a `Table` object, i.e. loads data
             # into memory.
             log.info("read %s rows of dataset %s into memory", n_rows_only, source_name)
-            data = source_ds.head(n_rows_only)
+            data = source_ds.head(
+                n_rows_only,
+                fragment_scan_options=ds.ParquetFragmentScanOptions(pre_buffer=False),
+            )
         else:
             log.info("read complete dataset %s into memory", source_name)
-            data = source_ds.to_table()
+            data = source_ds.to_table(
+                fragment_scan_options=ds.ParquetFragmentScanOptions(pre_buffer=False)
+            )
 
         log.info("read source dataset into memory in %.4f s", time.monotonic() - t0)
 


### PR DESCRIPTION
Fixes https://github.com/voltrondata-labs/arrow-benchmarks-ci/issues/166.

This PR sets `pre_buffer=False` when reading files in the `dataset-serialize` benchmark in order to avoid https://github.com/apache/arrow/issues/38438. 

Once that's fixed, we can probably come back and remove this.