### PR TITLE
Fix JS parsing

### DIFF
--- a/benchmarks/js_micro_benchmarks.py
+++ b/benchmarks/js_micro_benchmarks.py
@@ -54,9 +54,7 @@ class RecordJavaScriptMicroBenchmarks(_benchmark.Benchmark):
 
         run_command = get_run_command()
         _, err = self.execute_command(run_command)
-        # Ignore non-json stderr produced by JavaScript benchmarks
-        results_start = err.find("\n[")
-        results = json.loads(err[results_start:])
+        results = json.loads(err)
 
         # bucket by suite
         suites = {}


### PR DESCRIPTION
In the process of fixing JS benchmarks I noticed the parsing of the results wasn't working: https://github.com/apache/arrow/pull/37668#issuecomment-1781790381.

Something may have changed in `yarn` since the last time we ran these? not sure