### PR TITLE
doc(README.md): Fix the wrong path

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Options:
 
 More simple benchmark examples that have minimal scaffolding:
 
-* [csv_read_benchmark.py](https://github.com/voltrondata-labs/benchmarks/blob/main/benchmarks/csv_read_benchmark.py)
+* [csv_benchmark.py](https://github.com/voltrondata-labs/benchmarks/blob/main/benchmarks/csv_benchmark.py)
 * [dataset_filter_benchmark.py](https://github.com/voltrondata-labs/benchmarks/blob/main/benchmarks/dataset_filter_benchmark.py)
 * [dataset_select_benchmark.py](https://github.com/voltrondata-labs/benchmarks/blob/main/benchmarks/dataset_select_benchmark.py)
 


### PR DESCRIPTION
I have corrected the links that were causing a '404 Not Found' by updating the path and filename.