### PR TITLE
Bump cpp-micro repetitions to 6

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,6 +1,6 @@
 [
   {
-    "command": "cpp-micro --iterations=1",
+    "command": "cpp-micro",
     "flags": {
       "language": "C++"
     }

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,6 +1,6 @@
 [
   {
-    "command": "cpp-micro --iterations=1",
+    "command": "cpp-micro --iterations=20 --repetition_min_time=0.05",
     "flags": {
       "language": "C++"
     }

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,6 +1,6 @@
 [
   {
-    "command": "cpp-micro --iterations=20 --repetition_min_time=0.05",
+    "command": "cpp-micro --iterations=1",
     "flags": {
       "language": "C++"
     }

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -17,7 +17,7 @@ RUN_OPTIONS = {
         "type": int,
         "help": "Number of repetitions of each benchmark.",
     },
-    "repetition_min_time": {
+    "repetition-min-time": {
         "default": 0.05,
         "type": float,
         "help": "Minimum time to run iterations for one repetition of the benchmark.",
@@ -71,24 +71,13 @@ COMMON_OPTIONS = {
 
 def _get_cli_options(options: dict) -> List[str]:
     command_params = []
-    if options.get("iterations"):
-        command_params += ["--repetitions", str(options.get("iterations"))]
-    if options.get("repetition_min_time"):
-        command_params += [
-            "--repetition-min-time",
-            str(options.get("repetition_min_time")),
-        ]
-
-    _add_command_options(command_params, options)
-
-    return command_params
-
-
-def _add_command_options(command: List[str], options: dict):
-    for option in COMMON_OPTIONS.keys():
+    for option in list(COMMON_OPTIONS) + list(RUN_OPTIONS):
         value = options.get(option.replace("-", "_"), None)
         if value:
-            command.extend([f"--{option}", value])
+            command_params.extend([f"--{option}", value])
+
+    print(command_params)
+    return command_params
 
 
 @conbenchlegacy.runner.register_benchmark

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -15,7 +15,7 @@ RUN_OPTIONS = {
     "repetitions": {
         "default": 20,
         "type": int,
-        "help": "Number of repetitions of each benchmark.",
+        "help": "Number of repetitions to tell the executable to run.",
     },
     "repetition-min-time": {
         "default": 0.05,
@@ -74,9 +74,7 @@ def _get_cli_options(options: dict) -> List[str]:
     for option in list(COMMON_OPTIONS) + list(RUN_OPTIONS):
         value = options.get(option.replace("-", "_"), None)
         if value:
-            command_params.extend([f"--{option}", value])
-
-    print(command_params)
+            command_params.extend([f"--{option}", str(value)])
     return command_params
 
 
@@ -89,7 +87,7 @@ class RecordCppMicroBenchmarks(_benchmark.Benchmark):
     options = copy.deepcopy(COMMON_OPTIONS)
     options.update(**RUN_OPTIONS)
     description = "Run the Arrow C++ micro benchmarks."
-    iterations = 1  # only call the executable once; it handles repetitions internally
+    iterations = None  # the executable handles repetitions internally
     flags = {"language": "C++"}
     adapter = None
 

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -11,7 +11,7 @@ from benchmarks import _benchmark
 
 log.setLevel(logging.DEBUG)
 
-RUN_OPTIONS = {
+OPTIONS = {
     "repetitions": {
         "default": 20,
         "type": int,
@@ -22,10 +22,6 @@ RUN_OPTIONS = {
         "type": float,
         "help": "Minimum time to run iterations for one repetition of the benchmark.",
     },
-}
-
-
-COMMON_OPTIONS = {
     "src": {
         "default": None,
         "type": str,
@@ -71,7 +67,7 @@ COMMON_OPTIONS = {
 
 def _get_cli_options(options: dict) -> List[str]:
     command_params = []
-    for option in list(COMMON_OPTIONS) + list(RUN_OPTIONS):
+    for option in OPTIONS:
         value = options.get(option.replace("-", "_"), None)
         if value:
             command_params.extend([f"--{option}", str(value)])
@@ -84,8 +80,7 @@ class RecordCppMicroBenchmarks(_benchmark.Benchmark):
 
     external = True
     name = "cpp-micro"
-    options = copy.deepcopy(COMMON_OPTIONS)
-    options.update(**RUN_OPTIONS)
+    options = copy.deepcopy(OPTIONS)
     description = "Run the Arrow C++ micro benchmarks."
     iterations = None  # the executable handles repetitions internally
     flags = {"language": "C++"}

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 
 OPTIONS = {
     "repetitions": {
-        "default": 20,
+        "default": 10,
         "type": int,
         "help": "Number of repetitions to tell the executable to run.",
     },

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -15,7 +15,12 @@ RUN_OPTIONS = {
     "iterations": {
         "default": None,
         "type": int,
-        "help": "Number of iterations of each benchmark.",
+        "help": "Number of repetitions of each benchmark.",
+    },
+    "repetition_min_time": {
+        "default": None,
+        "type": float,
+        "help": "Minimum time to run iterations for one repetition of the benchmark.",
     },
 }
 
@@ -68,6 +73,11 @@ def _get_cli_options(options: dict) -> List[str]:
     command_params = []
     if options.get("iterations"):
         command_params += ["--repetitions", str(options.get("iterations"))]
+    if options.get("repetition_min_time"):
+        command_params += [
+            "--repetition-min-time",
+            str(options.get("repetition_min_time")),
+        ]
 
     _add_command_options(command_params, options)
 
@@ -90,7 +100,7 @@ class RecordCppMicroBenchmarks(_benchmark.Benchmark):
     options = copy.deepcopy(COMMON_OPTIONS)
     options.update(**RUN_OPTIONS)
     description = "Run the Arrow C++ micro benchmarks."
-    iterations = 1
+    iterations = 1  # only call the executable once; it handles repetitions internally
     flags = {"language": "C++"}
     adapter = None
 

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 
 OPTIONS = {
     "repetitions": {
-        "default": 10,
+        "default": 6,
         "type": int,
         "help": "Number of repetitions to tell the executable to run.",
     },

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -12,13 +12,13 @@ from benchmarks import _benchmark
 log.setLevel(logging.DEBUG)
 
 RUN_OPTIONS = {
-    "iterations": {
-        "default": None,
+    "repetitions": {
+        "default": 20,
         "type": int,
         "help": "Number of repetitions of each benchmark.",
     },
     "repetition_min_time": {
-        "default": None,
+        "default": 0.05,
         "type": float,
         "help": "Minimum time to run iterations for one repetition of the benchmark.",
     },

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -38,18 +38,18 @@ Options:
 
 def test_get_run_command():
     options = {
-        "iterations": 100,
+        "repetitions": 100,
         "suite_filter": "arrow-compute-vector-selection-benchmark",
         "benchmark_filter": "TakeStringRandomIndicesWithNulls/262144/2",
     }
     actual = cpp_micro_benchmarks._get_cli_options(options)
     assert actual == [
-        "--repetitions",
-        "100",
         "--suite-filter",
         "arrow-compute-vector-selection-benchmark",
         "--benchmark-filter",
         "TakeStringRandomIndicesWithNulls/262144/2",
+        "--repetitions",
+        "100",
     ]
 
 

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -11,24 +11,28 @@ Usage: conbench cpp-micro [OPTIONS]
   Run the Arrow C++ micro benchmarks.
 
 Options:
-  --src TEXT                 Specify Arrow source directory.
-  --suite-filter TEXT        Regex filtering benchmark suites.
-  --benchmark-filter TEXT    Regex filtering benchmarks.
-  --cmake-extras TEXT        Extra flags/options to pass to cmake invocation.
-  --cc TEXT                  C compiler.
-  --cxx TEXT                 C++ compiler.
-  --cxx-flags TEXT           C++ compiler flags.
-  --cpp-package-prefix TEXT  Value to pass for ARROW_PACKAGE_PREFIX and use
-                             ARROW_DEPENDENCY_SOURCE=SYSTEM.
-  --iterations INTEGER       Number of iterations of each benchmark.
-  --show-result BOOLEAN      [default: true]
-  --show-output BOOLEAN      [default: false]
-  --run-id TEXT              Group executions together with a run id.
-  --run-name TEXT            Free-text name of run (commit ABC, pull request
-                             123, etc).
-  --run-reason TEXT          Low-cardinality reason for run (commit, pull
-                             request, manual, etc).
-  --help                     Show this message and exit.
+  --src TEXT                   Specify Arrow source directory.
+  --suite-filter TEXT          Regex filtering benchmark suites.
+  --benchmark-filter TEXT      Regex filtering benchmarks.
+  --cmake-extras TEXT          Extra flags/options to pass to cmake
+                               invocation.
+  --cc TEXT                    C compiler.
+  --cxx TEXT                   C++ compiler.
+  --cxx-flags TEXT             C++ compiler flags.
+  --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
+                               ARROW_DEPENDENCY_SOURCE=SYSTEM.
+  --repetitions INTEGER        Number of repetitions of each benchmark.
+                               [default: 20]
+  --repetition-min-time FLOAT  Minimum time to run iterations for one
+                               repetition of the benchmark.  [default: 0.05]
+  --show-result BOOLEAN        [default: true]
+  --show-output BOOLEAN        [default: false]
+  --run-id TEXT                Group executions together with a run id.
+  --run-name TEXT              Free-text name of run (commit ABC, pull request
+                               123, etc).
+  --run-reason TEXT            Low-cardinality reason for run (commit, pull
+                               request, manual, etc).
+  --help                       Show this message and exit.
 """
 
 

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -11,6 +11,10 @@ Usage: conbench cpp-micro [OPTIONS]
   Run the Arrow C++ micro benchmarks.
 
 Options:
+  --repetitions INTEGER        Number of repetitions to tell the executable to
+                               run.  [default: 20]
+  --repetition-min-time FLOAT  Minimum time to run iterations for one
+                               repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.
   --suite-filter TEXT          Regex filtering benchmark suites.
   --benchmark-filter TEXT      Regex filtering benchmarks.
@@ -21,10 +25,6 @@ Options:
   --cxx-flags TEXT             C++ compiler flags.
   --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
                                ARROW_DEPENDENCY_SOURCE=SYSTEM.
-  --repetitions INTEGER        Number of repetitions to tell the executable to
-                               run.  [default: 20]
-  --repetition-min-time FLOAT  Minimum time to run iterations for one
-                               repetition of the benchmark.  [default: 0.05]
   --show-result BOOLEAN        [default: true]
   --show-output BOOLEAN        [default: false]
   --run-id TEXT                Group executions together with a run id.
@@ -44,12 +44,12 @@ def test_get_run_command():
     }
     actual = cpp_micro_benchmarks._get_cli_options(options)
     assert actual == [
+        "--repetitions",
+        "100",
         "--suite-filter",
         "arrow-compute-vector-selection-benchmark",
         "--benchmark-filter",
         "TakeStringRandomIndicesWithNulls/262144/2",
-        "--repetitions",
-        "100",
     ]
 
 

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -12,7 +12,7 @@ Usage: conbench cpp-micro [OPTIONS]
 
 Options:
   --repetitions INTEGER        Number of repetitions to tell the executable to
-                               run.  [default: 20]
+                               run.  [default: 10]
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -12,7 +12,7 @@ Usage: conbench cpp-micro [OPTIONS]
 
 Options:
   --repetitions INTEGER        Number of repetitions to tell the executable to
-                               run.  [default: 10]
+                               run.  [default: 6]
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -21,8 +21,8 @@ Options:
   --cxx-flags TEXT             C++ compiler flags.
   --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
                                ARROW_DEPENDENCY_SOURCE=SYSTEM.
-  --repetitions INTEGER        Number of repetitions of each benchmark.
-                               [default: 20]
+  --repetitions INTEGER        Number of repetitions to tell the executable to
+                               run.  [default: 20]
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --show-result BOOLEAN        [default: true]


### PR DESCRIPTION
This PR tells Archery to run each cpp microbenchmark executable with the instruction to do ~20~ 6 reps, where each rep runs as many iterations as it can in 0.05 seconds (or a bit more if it's statistically necessary). This should smooth out the data since we now alert on the "best rep" instead of the mean, resulting in fewer false positives and less outlier weight.