### PR TITLE
Use pre-built arrow for cpp benchmarks by default

### DIFF
--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -63,9 +63,10 @@ OPTIONS = {
         "help": "Value to pass for ARROW_PACKAGE_PREFIX and use ARROW_DEPENDENCY_SOURCE=SYSTEM.",
     },
     "rev-or-path": {
-        "default": "cpp",
+        "default": None,
         "type": str,
-        "help": "Git rev or path to already-built arrow. Set to '' to build yourself.",
+        "help": "Git rev or path to already-built arrow. Default is ${ARROW_SRC}/cpp "
+        "unless that env var is undefined (then build from scratch instead).",
     },
 }
 
@@ -73,11 +74,15 @@ OPTIONS = {
 def _get_cli_options(options: dict) -> List[str]:
     command_params = []
     for option in OPTIONS:
-        value = options.get(option.replace("-", "_"), None)
-        if value:
-            if option in {"rev-or-path"}:
-                command_params.append(str(value))
-            else:
+        if option == "rev-or-path":
+            value = options.get("rev_or_path", None)
+            if not value and os.getenv("ARROW_SRC"):
+                value = f"{os.getenv('ARROW_SRC')}/cpp"
+            if value:
+                command_params.append(value)
+        else:
+            value = options.get(option.replace("-", "_"), None)
+            if value:
                 command_params.extend([f"--{option}", str(value)])
     return command_params
 

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -65,7 +65,7 @@ OPTIONS = {
     "rev-or-path": {
         "default": None,
         "type": str,
-        "help": "Git rev or path to already-built arrow. Default is ${ARROW_SRC}/cpp "
+        "help": "Git rev or path to already-built arrow. Default is ${ARROW_SRC}/build/cpp "
         "unless that env var is undefined (then build from scratch instead).",
     },
 }
@@ -77,7 +77,7 @@ def _get_cli_options(options: dict) -> List[str]:
         if option == "rev-or-path":
             value = options.get("rev_or_path", None)
             if not value and os.getenv("ARROW_SRC"):
-                value = f"{os.getenv('ARROW_SRC')}/cpp"
+                value = f"{os.getenv('ARROW_SRC')}/build/cpp"
             if value:
                 command_params.append(value)
         else:

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -62,6 +62,11 @@ OPTIONS = {
         "type": str,
         "help": "Value to pass for ARROW_PACKAGE_PREFIX and use ARROW_DEPENDENCY_SOURCE=SYSTEM.",
     },
+    "rev-or-path": {
+        "default": "cpp",
+        "type": str,
+        "help": "Git rev or path to already-built arrow. Set to '' to build yourself.",
+    },
 }
 
 
@@ -70,7 +75,10 @@ def _get_cli_options(options: dict) -> List[str]:
     for option in OPTIONS:
         value = options.get(option.replace("-", "_"), None)
         if value:
-            command_params.extend([f"--{option}", str(value)])
+            if option in {"rev-or-path"}:
+                command_params.append(str(value))
+            else:
+                command_params.extend([f"--{option}", str(value)])
     return command_params
 
 

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 
 OPTIONS = {
     "repetitions": {
-        "default": 4,
+        "default": 3,
         "type": int,
         "help": "Number of repetitions to tell the executable to run.",
     },

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 
 OPTIONS = {
     "repetitions": {
-        "default": 6,
+        "default": 1,
         "type": int,
         "help": "Number of repetitions to tell the executable to run.",
     },

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -65,7 +65,7 @@ OPTIONS = {
     "rev-or-path": {
         "default": None,
         "type": str,
-        "help": "Git rev or path to already-built arrow. Default is ${ARROW_SRC}/build/cpp "
+        "help": "Git rev or path to already-built arrow. Default is ${ARROW_BUILD_DIR}/cpp "
         "unless that env var is undefined (then build from scratch instead).",
     },
 }
@@ -76,8 +76,8 @@ def _get_cli_options(options: dict) -> List[str]:
     for option in OPTIONS:
         if option == "rev-or-path":
             value = options.get("rev_or_path", None)
-            if not value and os.getenv("ARROW_SRC"):
-                value = f"{os.getenv('ARROW_SRC')}/build/cpp"
+            if not value and os.getenv("ARROW_BUILD_DIR"):
+                value = f"{os.getenv('ARROW_BUILD_DIR')}/cpp"
             if value:
                 command_params.append(value)
         else:

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -28,7 +28,7 @@ OPTIONS = {
         "help": "Specify Arrow source directory.",
     },
     "suite-filter": {
-        "default": "^(?!arrow-acero-aggregate-benchmark).*$",
+        "default": "^(?!arrow-acero-aggregate-benchmark)(?!arrow-filesystem-s3fs-benchmark).*$",
         "type": str,
         "help": "Regex filtering benchmark suites.",
     },

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -28,7 +28,7 @@ OPTIONS = {
         "help": "Specify Arrow source directory.",
     },
     "suite-filter": {
-        "default": None,
+        "default": "^(?!arrow-acero-aggregate-benchmark).*$",
         "type": str,
         "help": "Regex filtering benchmark suites.",
     },

--- a/benchmarks/cpp_micro_benchmarks.py
+++ b/benchmarks/cpp_micro_benchmarks.py
@@ -13,7 +13,7 @@ log.setLevel(logging.DEBUG)
 
 OPTIONS = {
     "repetitions": {
-        "default": 1,
+        "default": 4,
         "type": int,
         "help": "Number of repetitions to tell the executable to run.",
     },

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -26,8 +26,8 @@ Options:
   --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
                                ARROW_DEPENDENCY_SOURCE=SYSTEM.
   --rev-or-path TEXT           Git rev or path to already-built arrow. Default
-                               is ${ARROW_SRC}/cpp unless that env var is
-                               undefined (then build from scratch instead).
+                               is ${ARROW_SRC}/build/cpp unless that env var
+                               is undefined (then build from scratch instead).
   --show-result BOOLEAN        [default: true]
   --show-output BOOLEAN        [default: false]
   --run-id TEXT                Group executions together with a run id.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -17,7 +17,8 @@ Options:
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.
   --suite-filter TEXT          Regex filtering benchmark suites.  [default:
-                               ^(?!arrow-acero-aggregate-benchmark).*$]
+                               ^(?!arrow-acero-aggregate-benchmark)(?!arrow-
+                               filesystem-s3fs-benchmark).*$]
   --benchmark-filter TEXT      Regex filtering benchmarks.
   --cmake-extras TEXT          Extra flags/options to pass to cmake
                                invocation.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -12,7 +12,7 @@ Usage: conbench cpp-micro [OPTIONS]
 
 Options:
   --repetitions INTEGER        Number of repetitions to tell the executable to
-                               run.  [default: 4]
+                               run.  [default: 3]
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -25,6 +25,8 @@ Options:
   --cxx-flags TEXT             C++ compiler flags.
   --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
                                ARROW_DEPENDENCY_SOURCE=SYSTEM.
+  --rev-or-path TEXT           Git rev or path to already-built arrow. Set to
+                               '' to build yourself.  [default: cpp]
   --show-result BOOLEAN        [default: true]
   --show-output BOOLEAN        [default: false]
   --run-id TEXT                Group executions together with a run id.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -12,7 +12,7 @@ Usage: conbench cpp-micro [OPTIONS]
 
 Options:
   --repetitions INTEGER        Number of repetitions to tell the executable to
-                               run.  [default: 1]
+                               run.  [default: 4]
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -25,8 +25,9 @@ Options:
   --cxx-flags TEXT             C++ compiler flags.
   --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
                                ARROW_DEPENDENCY_SOURCE=SYSTEM.
-  --rev-or-path TEXT           Git rev or path to already-built arrow. Set to
-                               '' to build yourself.  [default: cpp]
+  --rev-or-path TEXT           Git rev or path to already-built arrow. Default
+                               is ${ARROW_SRC}/cpp unless that env var is
+                               undefined (then build from scratch instead).
   --show-result BOOLEAN        [default: true]
   --show-output BOOLEAN        [default: false]
   --run-id TEXT                Group executions together with a run id.

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -12,7 +12,7 @@ Usage: conbench cpp-micro [OPTIONS]
 
 Options:
   --repetitions INTEGER        Number of repetitions to tell the executable to
-                               run.  [default: 6]
+                               run.  [default: 1]
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.
@@ -26,7 +26,7 @@ Options:
   --cpp-package-prefix TEXT    Value to pass for ARROW_PACKAGE_PREFIX and use
                                ARROW_DEPENDENCY_SOURCE=SYSTEM.
   --rev-or-path TEXT           Git rev or path to already-built arrow. Default
-                               is ${ARROW_SRC}/build/cpp unless that env var
+                               is ${ARROW_BUILD_DIR}/cpp unless that env var
                                is undefined (then build from scratch instead).
   --show-result BOOLEAN        [default: true]
   --show-output BOOLEAN        [default: false]

--- a/benchmarks/tests/test_cpp_micro_benchmarks.py
+++ b/benchmarks/tests/test_cpp_micro_benchmarks.py
@@ -16,7 +16,8 @@ Options:
   --repetition-min-time FLOAT  Minimum time to run iterations for one
                                repetition of the benchmark.  [default: 0.05]
   --src TEXT                   Specify Arrow source directory.
-  --suite-filter TEXT          Regex filtering benchmark suites.
+  --suite-filter TEXT          Regex filtering benchmark suites.  [default:
+                               ^(?!arrow-acero-aggregate-benchmark).*$]
   --benchmark-filter TEXT      Regex filtering benchmarks.
   --cmake-extras TEXT          Extra flags/options to pass to cmake
                                invocation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 pandas
 pyarrow
-benchadapt@git+https://github.com/conbench/conbench.git@5a31507#subdirectory=benchadapt/python
-benchclients@git+https://github.com/conbench/conbench.git@5a31507#subdirectory=benchclients/python
-conbenchlegacy@git+https://github.com/conbench/conbench.git@5a31507#subdirectory=legacy
+benchadapt@git+https://github.com/conbench/conbench.git@8326988#subdirectory=benchadapt/python
+benchclients@git+https://github.com/conbench/conbench.git@8326988#subdirectory=benchclients/python
+conbenchlegacy@git+https://github.com/conbench/conbench.git@8326988#subdirectory=legacy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 pandas
 pyarrow
-benchadapt@git+https://github.com/conbench/conbench.git@8ac5166#subdirectory=benchadapt/python
-benchclients@git+https://github.com/conbench/conbench.git@8ac5166#subdirectory=benchclients/python
-conbenchlegacy@git+https://github.com/conbench/conbench.git@8ac5166#subdirectory=legacy
+benchadapt@git+https://github.com/conbench/conbench.git@5a31507#subdirectory=benchadapt/python
+benchclients@git+https://github.com/conbench/conbench.git@5a31507#subdirectory=benchclients/python
+conbenchlegacy@git+https://github.com/conbench/conbench.git@5a31507#subdirectory=legacy


### PR DESCRIPTION
Pairs well with https://github.com/voltrondata-labs/arrow-benchmarks-ci/pull/181 and https://github.com/apache/arrow/pull/40925.

This PR allows us to use the pre-built arrow for C++ benchmarks by passing its path through the env var. This also allows us to run more benchmark suites since the pre-built arrow has more stuff in it.