### PR TITLE
[Java] Add --add-opens to Java benchmark runner

### DIFF
--- a/benchmarks/java_micro_benchmarks.py
+++ b/benchmarks/java_micro_benchmarks.py
@@ -53,6 +53,8 @@ def get_run_command(filename, options):
         commit,
         "--language",
         "java",
+        "--java-options",
+        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED",
         "--output",
         filename,
     ]


### PR DESCRIPTION
Add `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` when running Java benchmarks.